### PR TITLE
 Make draggable button functionality generic, modify stem export save panel 

### DIFF
--- a/Mixer/AudioController.swift
+++ b/Mixer/AudioController.swift
@@ -681,9 +681,9 @@ extension AudioController : ChannelControllerDelegate {
         let format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 2)!
         return format
     }
-    public func soloValueChanges(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/) {
+    public func channelValueChanged(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/) {
         allChannelControllers.forEach { channelController in
-            channelController.didReceiveSoloValueChange(gestureRect: gestureRect, buttonType: buttonType, newState: newState)
+            channelController.didReceiveChannelValueChange(gestureRect: gestureRect, buttonType: buttonType, newState: newState)
         }
     }
 }

--- a/Mixer/Channel/ChannelCollectionViewItem.xib
+++ b/Mixer/Channel/ChannelCollectionViewItem.xib
@@ -15,6 +15,7 @@
                 <outlet property="labelViewTrailingConstraint" destination="7oZ-fm-66n" id="e90-5d-kb5"/>
                 <outlet property="mixerFillView" destination="rba-UR-U1f" id="Uve-KQ-JtG"/>
                 <outlet property="muteButton" destination="TKq-fY-h6f" id="DsD-cO-PXw"/>
+                <outlet property="mutePanGestureRecognizer" destination="jfI-gN-Bnn" id="UUY-9i-Hy4"/>
                 <outlet property="outputPopup" destination="PfA-sz-PFv" id="VMB-fI-dA8"/>
                 <outlet property="panKnob" destination="Ar8-yd-M5r" id="IYY-RK-ouU"/>
                 <outlet property="sendLevelKnob1" destination="RXO-TX-0OP" id="B21-bh-38f"/>
@@ -222,12 +223,15 @@
                         <constraint firstAttribute="width" constant="5" id="YV2-Ta-3ei"/>
                     </constraints>
                 </customView>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TKq-fY-h6f" userLabel="Mute">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TKq-fY-h6f" userLabel="Mute" customClass="DraggableButton" customModule="AudioFramework" customModuleProvider="target">
                     <rect key="frame" x="-6" y="15" width="42" height="32"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="21" id="69X-5g-jEm"/>
                         <constraint firstAttribute="width" constant="30" id="Rz4-e8-Dnw"/>
                     </constraints>
+                    <gestureRecognizers>
+                        <panGestureRecognizer delaysPrimaryMouseButtonEvents="YES" id="jfI-gN-Bnn" customClass="AFPanGestureRecognizer" customModule="AudioFramework" customModuleProvider="target"/>
+                    </gestureRecognizers>
                     <buttonCell key="cell" type="push" title="M" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1XM-3k-TEN">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                         <font key="font" metaFont="system"/>

--- a/Mixer/Channel/ChannelController.swift
+++ b/Mixer/Channel/ChannelController.swift
@@ -503,11 +503,11 @@ public class ChannelController : ChannelViewDelegate, AudioNodeFactoryDelegate {
     func resetMeter(){
         channelView?.updateVUMeter(level: 0)
     }
-    public func didReceiveSoloValueChange(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/) {
-        channelView?.soloValueChanges(gestureRect: gestureRect, buttonType: buttonType, newState: newState)
+    public func didReceiveChannelValueChange(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/) {
+        channelView?.channelValueChanged(gestureRect: gestureRect, buttonType: buttonType, newState: newState)
     }
-    public func soloValueChanged(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/) {
-        delegate.soloValueChanges(gestureRect: gestureRect, buttonType: buttonType, newState: newState)
+    public func channelValueChanged(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/) {
+        delegate.channelValueChanged(gestureRect: gestureRect, buttonType: buttonType, newState: newState)
     }
 }
 

--- a/Mixer/Channel/ChannelDelegates.swift
+++ b/Mixer/Channel/ChannelDelegates.swift
@@ -35,7 +35,7 @@ public protocol ChannelViewDelegate {
     func select(description: AudioComponentDescription, type: PluginType, number: Int)
     func getAudioComponentList(type: PluginType) -> [AVAudioUnitComponent]
 //    func didReceiveSoloValueChange(gestureRect: CGRect, buttonType: DraggableButtonType, newState: NSControl.StateValue)
-    func soloValueChanged(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/)
+    func channelValueChanged(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/)
 }
 
 public protocol ChannelControllerDelegate{
@@ -52,7 +52,7 @@ public protocol ChannelControllerDelegate{
     func contextBlock() -> AUHostMusicalContextBlock
     func connect(sourceNode: AVAudioNode, destinationNode: AVAudioNode, bus: Int?)
     func getAudioComponentList(type: PluginType) -> [AVAudioUnitComponent]
-    func soloValueChanges(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/)
+    func channelValueChanged(gestureRect: CGRect, buttonType: DraggableButtonType, newState: Bool/*NSControl.StateValue*/)
 }
 
 public enum ConnectionType {

--- a/StemCreator/StemCreatorViewController.swift
+++ b/StemCreator/StemCreatorViewController.swift
@@ -140,11 +140,11 @@ public class StemCreatorViewController: NSViewController {
         if buttonTitle == "Cancel" { cancel() }
     }  
     private func export(){
-        let savePanel = NSOpenPanel()
-        savePanel.canChooseFiles = false
-        savePanel.canChooseDirectories = true
+        let savePanel = NSSavePanel()
+        savePanel.canCreateDirectories = true
         savePanel.title = "Choose Destination Folder"
-        savePanel.begin { (result) in 
+        guard let window = NSApp.keyWindow else { return }
+        savePanel.beginSheetModal(for: window) { (result) in
             if result == NSApplication.ModalResponse.OK {
                 guard let url = savePanel.url else { return }
                 self.exportStems(destinationFolder: url)


### PR DESCRIPTION
Make draggable button functionality generic, extending it to the mute button, and fixing issue created by inadvertently setting the mute button's type DraggableButtton in the first place. Also, update stem report save panel to use NSSavePanel and allow creation of directories. 