### PR TITLE
Adjust the origin of the button for dragging calculations. 

### DIFF
--- a/AudioFrameworkDemo/AudioFrameworkDemo.entitlements
+++ b/AudioFrameworkDemo/AudioFrameworkDemo.entitlements
@@ -10,7 +10,7 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 </dict>
 </plist>

--- a/Mixer/WIP/DraggableButton.swift
+++ b/Mixer/WIP/DraggableButton.swift
@@ -42,7 +42,7 @@ class DraggableButton: NSButton {
         if newState == false, state == .off { return }
         
         var testFrame = frame
-        testFrame.origin.x = 30
+        testFrame.origin.x = testFrame.minX < 15 ? 0 : 30
         testFrame.size.width = 30
         testFrame = superview.convert(testFrame, to: nil)
         


### PR DESCRIPTION
Adjust the origin of the button based on a fudge factor, since the frame doesn't reflect the actual placement that results from using constraints. The end result is that comparisons of the buttons frame verses other run time coordinates produce expected, predictable results with the downside that it is fragile and prone to errors, such as if the layout of the buttons is changed in the future, for example.

This pull request also contains a modification to the entitlements to enable writing files, which was needed as part of stem export. 